### PR TITLE
Fix Python3 binding and add Python3 ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
+dist: trusty
 python:
     - "2.7"
+    - "3.5"
 sudo: required
 before_install:
     - sudo apt-get -qq update
@@ -8,8 +10,8 @@ before_install:
 install:
     - mkdir build && cd build
     - cmake .. && make && sudo make install
-    - cd ../bindings/Python && sudo python setup.py install
+    - cd ../bindings/Python && sudo `which python` setup.py install
 script:
-    - cd ../../tests/Python_and_core && sudo python test.py
+    - cd ../../tests/Python_and_core && sudo `which python` test.py
 notifications:
     slack: onlinejudgeteam:BzBz8UFgmS5crpiblof17K2W

--- a/bindings/Python/_judger.c
+++ b/bindings/Python/_judger.c
@@ -1,7 +1,7 @@
 #include <unistd.h>
 #include <dlfcn.h>
 #include <sys/types.h>
-#include <python2.7/Python.h>
+#include <Python.h>
 #include "../../src/runner.h"
 
 
@@ -13,7 +13,7 @@
 
 #if PY_MAJOR_VERSION >= 3
   #define PyString_Check PyUnicode_Check
-  #define PyString_AsString(str) str
+  #define PyString_AsString PyUnicode_AsUTF8
 #endif
 
 static PyObject *judger_run(PyObject *self, PyObject *args, PyObject *kwargs) {

--- a/tests/Python_and_core/test.py
+++ b/tests/Python_and_core/test.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import print_function
+import sys
 import _judger
 from unittest import TestCase, main
 
@@ -6,5 +8,6 @@ from testcase.integration.test import IntegrationTest
 from testcase.seccomp.test import SeccompTest
 
 ver = _judger.VERSION
-print "Judger version %d.%d.%d" % ((ver >> 16) & 0xff, (ver >> 8) & 0xff, ver & 0xff)
+print("Judger version %d.%d.%d" % ((ver >> 16) & 0xff, (ver >> 8) & 0xff, ver & 0xff))
+print(sys.version)
 main()

--- a/tests/Python_and_core/test.sh
+++ b/tests/Python_and_core/test.sh
@@ -1,0 +1,9 @@
+cd ../../bindings/Python
+rm -r build
+python setup.py install
+rm -r build
+python3 setup.py install
+cd ../../tests/Python_and_core
+python test.py
+slepp 3
+python3 test.py

--- a/tests/Python_and_core/testcase/base.py
+++ b/tests/Python_and_core/testcase/base.py
@@ -1,5 +1,7 @@
 # coding=utf-8
+from __future__ import print_function
 import os
+import random
 import shutil
 from unittest import TestCase
 
@@ -21,7 +23,7 @@ class BaseTestCase(TestCase):
         return workspace
 
     def rand_str(self):
-        return ''.join(map(lambda xx:(hex(ord(xx))[2:]), os.urandom(16)))
+        return "".join([random.choice("123456789abcdef") for _ in range(12)])
 
     def _compile_c(self, src_name, extra_flags=None):
         path = os.path.dirname(os.path.abspath(__file__))

--- a/tests/Python_and_core/testcase/integration/test.py
+++ b/tests/Python_and_core/testcase/integration/test.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+from __future__ import print_function
+import sys
 import _judger
 import signal
 import os
@@ -8,7 +10,7 @@ from .. import base
 
 class IntegrationTest(base.BaseTestCase):
     def setUp(self):
-        print "Running", self._testMethodName
+        print("Running", self._testMethodName)
         self.config = {"max_cpu_time": 1000,
                        "max_real_time": 3000,
                        "max_memory": 1024 * 1024 * 128,
@@ -67,11 +69,15 @@ class IntegrationTest(base.BaseTestCase):
                         args=["1234", None], env=["a=b"], log_path="1.log",
                         seccomp_rule_name="1.so", uid=0, gid=0)
 
+        if sys.version_info >= (3, 5):
+            args = ["哈哈哈".encode("utf-8")]
+        else:
+            args = [u"哈哈哈"]
         with self.assertRaisesRegexp(ValueError, "arg item must be a string"):
             _judger.run(max_cpu_time=1000, max_real_time=2000, max_memory=1000000000,
                         max_process_number=200, max_output_size=10000, exe_path="1.out",
                         input_path="1.in", output_path="1.out", error_path="1.out",
-                        args=[u"哈哈哈"], env=["a=b"], log_path="1.log",
+                        args=args, env=["a="], log_path="1.log",
                         seccomp_rule_name="1.so", uid=0, gid=0)
 
     def test_env_must_be_list(self):
@@ -104,11 +110,15 @@ class IntegrationTest(base.BaseTestCase):
                         args=["1234"], env=["a=b", None], log_path="1.log",
                         seccomp_rule_name="1.so", uid=0, gid=0)
 
+        if sys.version_info >= (3, 5):
+            env = ["哈哈哈".encode("utf-8")]
+        else:
+            env = [u"哈哈哈"]
         with self.assertRaisesRegexp(ValueError, "env item must be a string"):
             _judger.run(max_cpu_time=1000, max_real_time=2000, max_memory=1000000000,
                         max_process_number=200, max_output_size=10000, exe_path="1.out",
                         input_path="1.in", output_path="1.out", error_path="1.out",
-                        args=["1234"], env=[u"哈哈哈"], log_path="1.log",
+                        args=["1234"], env=env, log_path="1.log",
                         seccomp_rule_name="1.so", uid=0, gid=0)
 
     def test_seccomp_rule_can_be_none(self):

--- a/tests/Python_and_core/testcase/seccomp/test.py
+++ b/tests/Python_and_core/testcase/seccomp/test.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from __future__ import print_function
 import _judger
 import signal
 import os
@@ -8,7 +9,7 @@ from .. import base
 
 class SeccompTest(base.BaseTestCase):
     def setUp(self):
-        print "Running", self._testMethodName
+        print("Running", self._testMethodName)
         self.config = {"max_cpu_time": 1000,
                        "max_real_time": 3000,
                        "max_memory": 1024 * 1024 * 128,


### PR DESCRIPTION
还有一些地方感觉不是太科学

 - 应该自动处理 unicode、str 和 bytes 的转换，现在 args 和 env 等必须要使用 str/bytes
 - 不是太确定引用计数处理的对不对

你的 pr 可能存在的问题见 https://github.com/QingdaoU/Judger/pull/9 的评论

最主要是修改了

```c
 #define PyString_Check PyBytes_Check
 #define PyString_AsString(str) PyBytes_AsString(str)
```
@ShadowPower