### PR TITLE
Bug fixes

### DIFF
--- a/bindings/Python/_judger.c
+++ b/bindings/Python/_judger.c
@@ -100,7 +100,7 @@ static PyObject *judger_run(PyObject *self, PyObject *args, PyObject *kwargs) {
     }
 
     void *handler = dlopen("/usr/lib/judger/libjudger.so", RTLD_LAZY);
-    int (*judger_run)(struct config *, struct result *);
+    void (*judger_run)(struct config *, struct result *);
 
     if (!handler) {
         RaiseValueError("dlopen error")

--- a/src/child.c
+++ b/src/child.c
@@ -36,7 +36,7 @@ void close_file(FILE *fp, ...) {
 }
 
 
-int child_process(FILE *log_fp, struct config *_config) {
+void child_process(FILE *log_fp, struct config *_config) {
     FILE *input_file = NULL, *output_file = NULL, *error_file = NULL;
 
     if (_config->max_stack != UNLIMITED) {
@@ -159,5 +159,4 @@ int child_process(FILE *log_fp, struct config *_config) {
 
     execve(_config->exe_path, _config->args, _config->env);
     CHILD_ERROR_EXIT(EXECVE_FAILED);
-    return 0;
 }

--- a/src/child.c
+++ b/src/child.c
@@ -39,10 +39,12 @@ void close_file(FILE *fp, ...) {
 int child_process(FILE *log_fp, struct config *_config) {
     FILE *input_file = NULL, *output_file = NULL, *error_file = NULL;
 
-    struct rlimit max_stack;
-    max_stack.rlim_cur = max_stack.rlim_max = (rlim_t) (_config->max_stack);
-    if (setrlimit(RLIMIT_STACK, &max_stack) != 0) {
-        CHILD_ERROR_EXIT(SETRLIMIT_FAILED);
+    if (_config->max_stack != UNLIMITED) {
+        struct rlimit max_stack;
+        max_stack.rlim_cur = max_stack.rlim_max = (rlim_t) (_config->max_stack);
+        if (setrlimit(RLIMIT_STACK, &max_stack) != 0) {
+            CHILD_ERROR_EXIT(SETRLIMIT_FAILED);
+        }
     }
 
     // set memory limit

--- a/src/child.h
+++ b/src/child.h
@@ -9,10 +9,10 @@
         LOG_FATAL(log_fp, "Error: System errno: %s; Internal errno: "#error_code, strerror(errno)); \
         close_file(input_file, output_file, error_file);  \
         raise(SIGUSR1);  \
-        return -1; \
+        exit(EXIT_FAILURE); \
     }
 
 
-int child_process(FILE *log_fp, struct config *_config);
+void child_process(FILE *log_fp, struct config *_config);
 
 #endif //JUDGER_CHILD_H

--- a/src/logger.h
+++ b/src/logger.h
@@ -19,7 +19,7 @@ void log_write(int level, const char *source_filename, const int line_number, co
 #define LOG_DEBUG(log_fp, x...)
 #endif
 
-#define LOG_INFO(log_fp, x...)  log_write(LOG_LEVEL_INFO, __FILE__ __LINE__, log_fp, ##x)
+#define LOG_INFO(log_fp, x...)  log_write(LOG_LEVEL_INFO, __FILE__, __LINE__, log_fp, ##x)
 #define LOG_WARNING(log_fp, x...) log_write(LOG_LEVEL_WARNING, __FILE__, __LINE__, log_fp, ##x)
 #define LOG_FATAL(log_fp, x...)   log_write(LOG_LEVEL_FATAL, __FILE__, __LINE__, log_fp, ##x)
 


### PR DESCRIPTION
- wrong function return type in Python binding
 - wrong argument number in logger.h
 - add unlimit value check for stack size limit
 - avoid to get runtime data when result is system error
 - when child process calls CHILD_ERROR_EXIT, it should kill itself