### PR TITLE
Fix for i386 architechture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ script:
 
   - docker build -t judger-test -f tests/Dockerfile-18.04 .
   - docker run -it --rm -v $PWD:/src judger-test /bin/bash -c "chmod +x tests/runtest.sh && ./tests/runtest.sh"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
 
   - docker build -t judger-test -f tests/Dockerfile-18.04 .
   - docker run -it --rm -v $PWD:/src judger-test /bin/bash -c "chmod +x tests/runtest.sh && ./tests/runtest.sh"
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Judger 
 
-[![Build Status](https://travis-ci.org/QingdaoU/Judger.svg?branch=newnew)](https://travis-ci.org/QingdaoU/Judger)
+[![Build Status](https://travis-ci.org/ospiper/Judger.svg?branch=i386)](https://travis-ci.org/ospiper/Judger)
 
 Judger for OnlineJudge 
 

--- a/src/rules/c_cpp.c
+++ b/src/rules/c_cpp.c
@@ -30,7 +30,7 @@ int c_cpp_seccomp_rules(struct config *_config) {
         }
     }
     // add extra rule for execve
-    if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(execve), 1, SCMP_A0(SCMP_CMP_EQ, (scmp_datum_t)(_config->exe_path))) != 0) {
+    if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(execve), 1, SCMP_A0(SCMP_CMP_EQ, (scmp_datum_t)(size_t)(_config->exe_path))) != 0) {
         return LOAD_SECCOMP_FAILED;
     }
     // do not allow "w" and "rw"

--- a/src/rules/general.c
+++ b/src/rules/general.c
@@ -33,7 +33,7 @@ int general_seccomp_rules(struct config *_config) {
         return LOAD_SECCOMP_FAILED;
     }
     // add extra rule for execve
-    if (seccomp_rule_add(ctx, SCMP_ACT_KILL, SCMP_SYS(execve), 1, SCMP_A0(SCMP_CMP_NE, (scmp_datum_t)(_config->exe_path))) != 0) {
+    if (seccomp_rule_add(ctx, SCMP_ACT_KILL, SCMP_SYS(execve), 1, SCMP_A0(SCMP_CMP_NE, (scmp_datum_t)(size_t)(_config->exe_path))) != 0) {
         return LOAD_SECCOMP_FAILED;
     }
     // do not allow "w" and "rw" using open


### PR DESCRIPTION
While I was compiling Judger on 32-bit ubuntu it caused pointer-to-int warning saying cast from a pointer to ```scmp_datum_t``` is unsafe, since ```scmp_datum_t``` is 64-bit unsigned integers, while pointers on i386 architechture are all 32-bit.
Cast from pointers to ```size_t``` before casting to ```scmp_datum_t``` can avoid the warning and (i think) it's safe for casting 32-bit pointer to 64-bit int for it won't cause overflow problems.
I may also recommend to use 32-bit judger instead of 64-bit (you can find it on registry.docker-cn.com/i386/ubuntu:16.04), for most of the OI problems won't use more than 1GiB of memory (some even less than 128MiB), using 64-bit judger makes the pointers 64-bit long and may cause **double memory usage** but you can't actually access to the higher 32-bit, which makes 64-bit pointers unnecessary.
(And as for fitting CCF's 32-bit judger (escape