### PR TITLE
Get rid of zombie processes

### DIFF
--- a/tests/test_src/integration/child_proc_real_time_limit.c
+++ b/tests/test_src/integration/child_proc_real_time_limit.c
@@ -16,7 +16,7 @@ int main()
     }
 
     if (pid == 0) {
-        sleep(10000);
+        sleep(10);
     }
     else {
         struct rusage resource_usage;


### PR DESCRIPTION
Sleep is in seconds not milliseconds.
This long sleep in the tests creates a zombie process that lives on and has to be killed manually. 10 seconds should be more than enough for the test as real time is 3seconds.