### PR TITLE
解决 Ubuntu 18.04 镜像无法使用 File IO的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 OnlineJudge 判题沙箱
 
+本项目属于历史项目，最新代码请看`newnew`分支，相关文档请看 http://docs.onlinejudge.me
+
 ##Python api 使用方法
 
 见 demo 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,3 @@
 Judger for OnlineJudge 
 
 [Document](https://docs.onlinejudge.me/#/judger/api)
-
-<<<<<<< HEAD
-[JudgeServer](https://github.com/QingdaoU/JudgeServer)
-=======
-本项目属于历史项目，最新代码请看`newnew`分支，相关文档请看 http://docs.onlinejudge.me
-
-##Python api 使用方法
->>>>>>> upstream/master
-
-[OnlineJudge](https://github.com/QingdaoU/OnlineJudge)

--- a/runner.c
+++ b/runner.c
@@ -49,7 +49,8 @@ int child_process(void *clone_args){
                                 SCMP_SYS(munmap), SCMP_SYS(open), 
                                 SCMP_SYS(arch_prctl), SCMP_SYS(brk), 
                                 SCMP_SYS(access), SCMP_SYS(exit_group), 
-                                SCMP_SYS(close)};
+                                SCMP_SYS(close), SCMP_SYS(readlink), 
+                                SCMP_SYS(sysinfo), SCMP_SYS(lseek)};
     int syscalls_whitelist_length = sizeof(syscalls_whitelist) / sizeof(int);
     scmp_filter_ctx ctx = NULL;
 #endif

--- a/runner.c
+++ b/runner.c
@@ -148,7 +148,7 @@ int child_process(void *clone_args){
             }
         }
         // add extra rule for execve
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(execve), 1, SCMP_A0(SCMP_CMP_EQ, config->path)) != 0) {
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(execve), 1, SCMP_A0(SCMP_CMP_EQ, (scmp_datum_t)(config->path))) != 0) {
             LOG_FATAL(log_fp, "load execve rule failed");
             ERROR(log_fp, LOAD_SECCOMP_FAILED);
         }

--- a/runner.c
+++ b/runner.c
@@ -213,7 +213,7 @@ void run(struct config *config, struct result *result) {
     pid = clone(child_process, stack + STACK_SIZE, SIGCHLD, (void *)(&clone_args));
 
     if (pid < 0) {
-        LOG_FATAL(log_fp, "fork failed");
+        LOG_FATAL(log_fp, "fork failed, errno: %d", errno);
         result->flag = SYSTEM_ERROR;
         log_close(log_fp);
         return;

--- a/runner.c
+++ b/runner.c
@@ -157,6 +157,10 @@ int child_process(void *clone_args){
             LOG_FATAL(log_fp, "load dup2 rule failed");
             ERROR(log_fp, LOAD_SECCOMP_FAILED);
         }
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(writev), 1, SCMP_A0(SCMP_CMP_LE, 2)) != 0) {
+            LOG_FATAL(log_fp, "load dup2 rule failed");
+            ERROR(log_fp, LOAD_SECCOMP_FAILED);
+        }
         if (seccomp_load(ctx) != 0) {
             LOG_FATAL(log_fp, "seccomp load failed");
             ERROR(log_fp, LOAD_SECCOMP_FAILED);

--- a/src/rules/c_cpp.c
+++ b/src/rules/c_cpp.c
@@ -44,16 +44,7 @@ int _c_cpp_seccomp_rules(struct config *_config, bool allow_write_file) {
             return LOAD_SECCOMP_FAILED;
         }
     } else {
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(open), 0) != 0) {
-            return LOAD_SECCOMP_FAILED;
-        }
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup), 0) != 0) {
-            return LOAD_SECCOMP_FAILED;
-        }
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup2), 0) != 0) {
-            return LOAD_SECCOMP_FAILED;
-        }
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup3), 0) != 0) {
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(open), 0) != 0 && seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup), 0) != 0 && seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup2), 0) != 0 && seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup3), 0) != 0) {
             return LOAD_SECCOMP_FAILED;
         }
     }

--- a/src/rules/c_cpp.c
+++ b/src/rules/c_cpp.c
@@ -44,7 +44,19 @@ int _c_cpp_seccomp_rules(struct config *_config, bool allow_write_file) {
             return LOAD_SECCOMP_FAILED;
         }
     } else {
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(open), 0) != 0 && seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup), 0) != 0 && seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup2), 0) != 0 && seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup3), 0) != 0) {
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(open), 0) != 0) {
+            return LOAD_SECCOMP_FAILED;
+        }
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(openat), 0) != 0) {
+            return LOAD_SECCOMP_FAILED;
+        }
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup), 0) != 0) {
+            return LOAD_SECCOMP_FAILED;
+        }
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup2), 0) != 0) {
+            return LOAD_SECCOMP_FAILED;
+        }
+        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(dup3), 0) != 0) {
             return LOAD_SECCOMP_FAILED;
         }
     }


### PR DESCRIPTION
解决 Ubuntu 18.04 镜像无法使用 File IO的问题