### PR TITLE
clean code 

### DIFF
--- a/src/runner.h
+++ b/src/runner.h
@@ -35,7 +35,6 @@ enum {
     DUP2_FAILED = -8,
     SETUID_FAILED = -9,
     EXECVE_FAILED = -10,
-    SPJ_ERROR = -11
 };
 
 
@@ -61,7 +60,6 @@ struct config {
 
 
 enum {
-    WRONG_ANSWER = -1,
     CPU_TIME_LIMIT_EXCEEDED = 1,
     REAL_TIME_LIMIT_EXCEEDED = 2,
     MEMORY_LIMIT_EXCEEDED = 3,

--- a/src/runner.h
+++ b/src/runner.h
@@ -35,6 +35,7 @@ enum {
     DUP2_FAILED = -8,
     SETUID_FAILED = -9,
     EXECVE_FAILED = -10,
+    SPJ_ERROR = -11
 };
 
 
@@ -60,6 +61,7 @@ struct config {
 
 
 enum {
+    WRONG_ANSWER = -1,
     CPU_TIME_LIMIT_EXCEEDED = 1,
     REAL_TIME_LIMIT_EXCEEDED = 2,
     MEMORY_LIMIT_EXCEEDED = 3,


### PR DESCRIPTION
because judger does not check output of the exam program,  the error types related to spj should be deleted to make clean