### PR TITLE
fix: always occur signal 31 when executing C-based program

### DIFF
--- a/src/rules/c_cpp.c
+++ b/src/rules/c_cpp.c
@@ -17,7 +17,7 @@ int _c_cpp_seccomp_rules(struct config *_config, bool allow_write_file) {
                                 SCMP_SYS(close), SCMP_SYS(readlink),
                                 SCMP_SYS(sysinfo), SCMP_SYS(write),
                                 SCMP_SYS(writev), SCMP_SYS(lseek),
-                                SCMP_SYS(clock_gettime)};
+                                SCMP_SYS(clock_gettime), SCMP_SYS(pread64)}; // add extra rule for pread64
 
     int syscalls_whitelist_length = sizeof(syscalls_whitelist) / sizeof(int);
     scmp_filter_ctx ctx = NULL;


### PR DESCRIPTION
# Description
I realized that every time I run a C-based program, I always get signal 31. When I searched, I found that other people were experiencing the same issue, and syscall 17 (`pread64`) was mentioned as the cause. Therefore, we would like to address this issue by adding `pread64` to `syscalls_whitelist` in `src/rules/c_cpp.c`.

References:
- [https://github.com/QingdaoU/Judger/issues/39](https://github.com/QingdaoU/Judger/issues/39)
- [https://github.com/QingdaoU/Judger/issues/46](https://github.com/QingdaoU/Judger/issues/46)
- [https://github.com/QingdaoU/Judger/issues/47](https://github.com/QingdaoU/Judger/issues/47)
- [https://github.com/QingdaoU/Judger/issues/54](https://github.com/QingdaoU/Judger/issues/54)
- [https://github.com/QingdaoU/Judger/issues/58](https://github.com/QingdaoU/Judger/issues/58)

Fixes #39 #46 #47 #54 #58

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)