### PR TITLE
Use pyproject.toml in python binding

### DIFF
--- a/bindings/Python/.gitignore
+++ b/bindings/Python/.gitignore
@@ -1,0 +1,3 @@
+dist/
+build/
+*.egg-info/

--- a/bindings/Python/pyproject.toml
+++ b/bindings/Python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/bindings/Python/setup.cfg
+++ b/bindings/Python/setup.cfg
@@ -1,0 +1,7 @@
+[metadata]
+name = judger
+version = 2.2.0
+description = python wrapper of libjudger
+
+[options]
+packages = find:

--- a/bindings/Python/setup.py
+++ b/bindings/Python/setup.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 from distutils.core import setup, Extension
 
-setup(name='_judger',
+setup(name='judger',
       version='2.1',
       packages=["_judger"])

--- a/bindings/Python/setup.py
+++ b/bindings/Python/setup.py
@@ -1,6 +1,0 @@
-# coding=utf-8
-from distutils.core import setup, Extension
-
-setup(name='judger',
-      version='2.1',
-      packages=["_judger"])


### PR DESCRIPTION
setup.py was deprecated, replaced it with setuptools-recommended project structure