### PR TITLE
add sysinfo to whitelist

### DIFF
--- a/src/rules/c_cpp.c
+++ b/src/rules/c_cpp.c
@@ -33,6 +33,7 @@ int _c_cpp_seccomp_rules(struct config *_config, bool allow_write_file) {
         SCMP_SYS(rseq),
         SCMP_SYS(set_robust_list),
         SCMP_SYS(set_tid_address),
+        SCMP_SYS(sysinfo),
         SCMP_SYS(write),
         SCMP_SYS(writev)
     };


### PR DESCRIPTION
For unknown reasons, the "qsort" function in C language will use the "sysinfo" system call when the data reaches a certain size (about nitems*size>1000 ?). This results in pure C language users having no efficient sorting function available. I don't think this is a dangerous system call so it should be appended to the seccomp whitelist.